### PR TITLE
Add Authorization header to address update

### DIFF
--- a/app/api/order.client.ts
+++ b/app/api/order.client.ts
@@ -74,10 +74,15 @@ export async function setOrderAddressEmailAndAddressesAPIClient(params: {
 }) {
     const { token, email, billingAddress, shippingAddress } = params;
     const API_URL = window?.ENV?.API_URL || "";
+    const jwtToken =
+        typeof window !== "undefined" ? localStorage.getItem("jwtToken") : null;
 
     const res = await fetch(`${API_URL}/api/v2/shop/orders/${token}/address`, {
         method: "PATCH",
-        headers: { "Content-Type": "application/merge-patch+json" },
+        headers: {
+            "Content-Type": "application/merge-patch+json",
+            ...(jwtToken ? { Authorization: `Bearer ${jwtToken}` } : {}),
+        },
         body: JSON.stringify({
             email,
             billingAddress,


### PR DESCRIPTION
## Summary
- retrieve JWT token from `localStorage` in the browser
- include `Authorization: Bearer <token>` header when calling `setOrderAddressEmailAndAddressesAPIClient`

## Testing
- `yarn lint` *(fails: fetch to registry blocked)*
- `yarn typecheck` *(fails: fetch to registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68501b3a243083208609fedc079098bc